### PR TITLE
Tests for makeShapeWithElementMap

### DIFF
--- a/tests/src/Mod/Part/App/TopoShapeMakeShapeWithElementMap.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeMakeShapeWithElementMap.cpp
@@ -9,6 +9,13 @@
 #include <Mod/Part/App/TopoShape.h>
 
 #include <TopoDS_Vertex.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Wire.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Shell.hxx>
+#include <TopoDS_Solid.hxx>
+#include <TopoDS_CompSolid.hxx>
+#include <TopoDS_Compound.hxx>
 
 class TopoShapeMakeShapeWithElementMapTests: public ::testing::Test
 {
@@ -48,14 +55,53 @@ private:
     Part::TopoShape::Mapper _mapper;
 };
 
-TEST_F(TopoShapeMakeShapeWithElementMapTests, nullShapeThrows)
+TEST_F(TopoShapeMakeShapeWithElementMapTests, nullShapesThrows)
 {
     // Arrange
     auto [cube1, cube2] = TopoShapeExpansionHelpers::CreateTwoCubes();
     std::vector<Part::TopoShape> sources {cube1, cube2};
-    TopoDS_Vertex nullShape;
+    TopoDS_Vertex nullVertex;
+    TopoDS_Edge nullEdge;
+    TopoDS_Wire nullWire;
+    TopoDS_Face nullFace;
+    TopoDS_Shell nullShell;
+    TopoDS_Solid nullSolid;
+    TopoDS_CompSolid nullCompSolid;
+    TopoDS_Compound nullCompound;
 
     // Act and assert
-    EXPECT_THROW(Shape()->makeShapeWithElementMap(nullShape, *Mapper(), sources),
+    EXPECT_THROW(Shape()->makeShapeWithElementMap(nullVertex, *Mapper(), sources),
                  Part::NullShapeException);
+    EXPECT_THROW(Shape()->makeShapeWithElementMap(nullEdge, *Mapper(), sources),
+                 Part::NullShapeException);
+    EXPECT_THROW(Shape()->makeShapeWithElementMap(nullWire, *Mapper(), sources),
+                 Part::NullShapeException);
+    EXPECT_THROW(Shape()->makeShapeWithElementMap(nullFace, *Mapper(), sources),
+                 Part::NullShapeException);
+    EXPECT_THROW(Shape()->makeShapeWithElementMap(nullShell, *Mapper(), sources),
+                 Part::NullShapeException);
+    EXPECT_THROW(Shape()->makeShapeWithElementMap(nullSolid, *Mapper(), sources),
+                 Part::NullShapeException);
+    EXPECT_THROW(Shape()->makeShapeWithElementMap(nullCompSolid, *Mapper(), sources),
+                 Part::NullShapeException);
+    EXPECT_THROW(Shape()->makeShapeWithElementMap(nullCompound, *Mapper(), sources),
+                 Part::NullShapeException);
+}
+
+TEST_F(TopoShapeMakeShapeWithElementMapTests, emptySourceShapes)
+{
+    // Arrange
+    auto [cube1, cube2] = TopoShapeExpansionHelpers::CreateTwoCubes();
+    std::vector<Part::TopoShape> emptySources;
+    std::vector<Part::TopoShape> nonEmptySources {cube1, cube2};
+
+    // Act and assert
+    for (auto& source : nonEmptySources) {
+        Part::TopoShape& modifiedShape = source;
+        Part::TopoShape& originalShape = source;
+
+        EXPECT_EQ(
+            &originalShape,
+            &modifiedShape.makeShapeWithElementMap(source.getShape(), *Mapper(), emptySources));
+    }
 }

--- a/tests/src/Mod/Part/App/TopoShapeMakeShapeWithElementMap.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeMakeShapeWithElementMap.cpp
@@ -133,8 +133,10 @@ TEST_F(TopoShapeMakeShapeWithElementMapTests, findShapeInElementMap)
     // Arrange
     auto [cube1, cube2] = TopoShapeExpansionHelpers::CreateTwoCubes();
     std::vector<Part::TopoShape> sources {cube1, cube2};
-    sources[0].Tag = 1;
-    sources[1].Tag = 2;
+    sources[0].Tag = 1;  // setting Tag explicitly otherwise it is likely that this test will be
+                         // more or less the same of nonMappableSources
+    sources[1].Tag = 2;  // setting Tag explicitly otherwise it is likely that this test will be
+                         // more or less the same of nonMappableSources
     Part::TopoShape cmpdShape;
     cmpdShape.makeElementCompound(sources);
 


### PR DESCRIPTION
 * Added nullShapesThrows tests for the classes derived from <TopoDS_Shape>
 * Added test passing as "sources" parameter of the tested method an empty vector of TopoShapes objects