### PR TITLE
Update clang-tidy configuration to exclude vararg check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,7 +5,7 @@ concurrency-*,-modernize-use-trailing-return-type, -modernize-use-nodiscard,-rea
 -readability-redundant-access-specifiers,-readability-qualified-auto,
 -cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-owning-memory,
 -readability-convert-member-functions-to-static,-bugprone-easily-swappable-parameters,
--cppcoreguidelines-pro-type-static-cast-downcast'
+-cppcoreguidelines-pro-type-static-cast-downcast,-cppcoreguidelines-pro-type-vararg'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 FormatStyle:     file


### PR DESCRIPTION
This is just noise in the FreeCAD codebase, which regularly interacts with pure-C varargs methods via cpython.